### PR TITLE
updating typedefs so media can be null

### DIFF
--- a/client/src/components/DogComponents/dogmap.js
+++ b/client/src/components/DogComponents/dogmap.js
@@ -86,7 +86,7 @@ function DogMap() {
         center={[34.0195, -118.4912]}
         zoom={7}
         scrollWheelZoom={false}
-        style={{ width: "50%", height: "80vh" }}
+        style={{ width: "70%", height: "80vh" }}
         ref={mapJump}
       >
         <TileLayer

--- a/client/src/utils/queries.js
+++ b/client/src/utils/queries.js
@@ -80,20 +80,24 @@ query Query($dogId: ID!) {
 // get all dogs by location or all-
 
 export const GET_DOGS = gql`
-  query Dogs {
-    dogs {
-      _id
-      bio
-      breed
+query Dogs {
+  dogs {
+    _id
+    bio
+    breed
+    location
+    endorsements {
+      counter
+      playStyle
+    }
+    name
+    userReference {
       location
-      endorsements {
-        counter
-        playStyle
-      }
-      name
-      userReference {
-        location
-      }
+    }
+    media {
+      _id
+      content
     }
   }
+}
 `;

--- a/server/models/Media.js
+++ b/server/models/Media.js
@@ -2,8 +2,8 @@ const { Schema, model } = require('mongoose');
 
 const mediaSchema = new Schema({
    content: {
-      type: String,
-      required: [true, 'Media content is required'],
+      type: String,   
+
    },
    isBanner: {
       type: Boolean,

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -32,8 +32,8 @@ const typeDefs = gql`
   }
 
   type Media {
-    _id: ID!
-    content: String!
+    _id: ID
+    content: String
     isBanner: Boolean
     isProfile: Boolean
   }


### PR DESCRIPTION
this update:

removes required fields from typedefs on Media Type: id and content are allowed to be null
re-added media back to GetDogs query as it no longer breaks call